### PR TITLE
add routes: get titles and quantity

### DIFF
--- a/backends/routes/schedule_routes.py
+++ b/backends/routes/schedule_routes.py
@@ -3,6 +3,7 @@ from flask import (
 )
 from flask import session
 from typing import List, Dict
+from datetime import datetime, timedelta
 
 bp = Blueprint('schedule', __name__, url_prefix='/schedule')
 
@@ -136,6 +137,39 @@ def quantity():
     """
     from core.core import scheduler
     quantity = scheduler.get_schedule_quantity()
+    return jsonify({'quantity': quantity})
+
+@bp.route('/titles/<int:days>', methods=['GET'])
+def tomorrow_titles(days: int):
+    """
+    Get the titles of schedules for tomorrow.
+
+    Returns:
+        JSON: {'titles': schedule titles for tomorrow}
+    """
+    from core.core import scheduler
+    schedules = scheduler.get_schedules()
+    titles = []
+    target_date = (datetime.now() + timedelta(days=days)).date()
+    for schedule in schedules:
+        schedule_date = datetime.strptime(schedule['content']['end_time'][0], '%Y-%m-%d').date()
+        if schedule_date == target_date:
+            titles.append(schedule['content']['title'])
+    print(f"Titles for tomorrow ({days} days later): {titles}")
+    return jsonify({'titles': titles})
+
+@bp.route('/quantity/<int:days>', methods=['GET'])
+def tomorrow_quantity(days: int):
+    """
+    Get the quantity of schedules for tomorrow.
+
+    Returns:
+        JSON: {'quantity': int} - The number of schedules for tomorrow
+    """
+    from core.core import scheduler
+    schedules = scheduler.get_schedules()
+    target_date = (datetime.now() + timedelta(days=days)).date()
+    quantity = sum(1 for schedule in schedules if datetime.strptime(schedule['content']['end_time'][0], '%Y-%m-%d').date() == target_date)
     return jsonify({'quantity': quantity})
 
 @bp.after_app_request

--- a/backends/tests/chat_individual.py
+++ b/backends/tests/chat_individual.py
@@ -31,5 +31,19 @@ def test_independent_requests():
     print("Response 3:", response3.json())
     print(f"Session ID from Response 3: {response3.cookies.get('session')}")
 
+def test_pet_routes():
+    for i in range(3):
+        response = requests.get(
+            f"{BASE_URL}/schedule/titles/{i}",
+        )
+        print(f"Response for schedule/titles/{i}:\n", response.json())
+
+        response = requests.get(
+            f"{BASE_URL}/schedule/quantity/{i}",
+        )
+        print(f"Response for schedule/quantity/{i}:\n", response.json())
+
 if __name__ == "__main__":
-    test_independent_requests()
+    # test_independent_requests()
+
+    test_pet_routes()

--- a/backends/tests/test_schedule_routes.py
+++ b/backends/tests/test_schedule_routes.py
@@ -138,7 +138,16 @@ def test_sync_schedules(client):
     assert response.status_code == 200    
     assert response.json == {'schedules': test_schedules}
     
+def test_pet_routes(client):
+    """Test GET /tomorrow/<id>/titles and /quantity routes"""
+    for i in range(3):
+        response_titles = client.get(f"/schedule/titles/{i}")
+        assert response_titles.status_code == 200
+        assert isinstance(response_titles.json(), dict)
 
+        response_quantity = client.get(f"/schedule/quantity/{i}")
+        assert response_quantity.status_code == 200
+        assert isinstance(response_quantity.json(), dict)
 
 '''
 def test_invalid_method(client):


### PR DESCRIPTION
添加了pet所需的两个接口，包括：

+ /schedule/titles/<int> 返回 List[str] 包含与今天间隔 <int> 天 (0, 1, 2, ...) 的日程的 title
+ /schedule/quantity/<int> 返回 int 包含与今天间隔 <int> 天 (0, 1, 2, ...) 的日程的个数