### PR TITLE
意图识别优化和单词错误修改

### DIFF
--- a/backends/core/ai_utils/ai_schedule_manager.py
+++ b/backends/core/ai_utils/ai_schedule_manager.py
@@ -72,7 +72,7 @@ class AIScheduleManager:
             )
             
             result = response.choices[0].message.content.strip().upper()
-            return result if result in ["CREATE", "MODIFY", "DELETE", "INQUERY"] else "GENERAL"
+            return result if result in ["CREATE", "MODIFY", "DELETE", "INQUIRY"] else "GENERAL"
         except Exception as e:
             print(f"语义分析出错: {e}")
             return "GENERAL"
@@ -193,9 +193,9 @@ class AIScheduleManager:
             return {"error": str(e)}
         
         
-    def _handle_inquery_response(self, prompt_content: List[Dict[str, str]]) -> Dict[str, Dict]:
+    def _handle_inquiry_response(self, prompt_content: List[Dict[str, str]]) -> Dict[str, Dict]:
         """
-        处理修改日程的响应（内部方法）
+        处理查询日程的响应（内部方法）
         返回格式：{
             "schedule_list" : 查询到的日程列表， # 必须字段
         }

--- a/backends/routes/chat_routes.py
+++ b/backends/routes/chat_routes.py
@@ -39,7 +39,7 @@ def chat():
 
     from core.core import scheduler
     # print(f"Received message: {message}")
-    res = scheduler.process_user_request({'word': message})
+    res = scheduler.process_user_request({'word': message}, messages)
     schedule: Dict = {}
     response: str = ""
     if isinstance(res, dict):
@@ -59,7 +59,7 @@ def chat():
         elif res['action'] == 'delete':
             response = f"成功删除日程: {res['schedule_title']} (id={res['schedule_id']})"
 
-        elif res['action'] == 'inquery':
+        elif res['action'] == 'inquiry':
             schedule_list = res['schedule_list']
 
             ds_messages = [


### PR DESCRIPTION
本次PR说明：
1. 优化了意图分析器的prompt，收紧了general的定义，使它能更好的意图识别。
2. 修改了ai_scheduler的对话来源为chat_routes里面的messages
3. 修改了inquery单词拼写错误为inquiry

个人测试中，整体意图识别的正确率基本为100%。但是有问题如下：
1. 用户输入为：“明天我有什么安排”，能正确识别为inquiry意图，且返回结果为空的时候，返回的回答是：“今日无日程安排”。
2. 用户连续输入“我下周四去顺德”，“玩完顺德第二天我准备去汕头”。都能正常识别为CREATE，但是“汕头玩完后我想去香港”也会被识别为CREATE意图，创建日程在汕头的下一天，即使并没有明确的时间规划。
而且“香港有什么地标性建筑，我去玩汕头想去看看”，也出现了一次被识别为CREATE的情况。

3. 目前的创造、修改、删除都只具备对一个日程进行操作的能力。不能做到“我下周所有安排取消”之类的行为。
4. 无法识别复合类意图，“我下周五10：00开会，删除前几天的旅游计划”。只能识别到DELETE，同时容易触及大模型能力边界导致删除出错。
5. 目前的设置对用户输入“我明天早上有一场比赛”的反馈较差，会设置为明天晚上23:59:59提醒。